### PR TITLE
Small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 s3-recursive-acl
 vendor
+.idea/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:b39fa3f439b5d90be1d5c1a1aff98ae1c1426b329a117343eb0edae455f19e31"
+  digest = "1:2b4057da5e55bd54d7e57b36f00ace2f42917946aab9b47d83e81dae4e5a0d2f"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -14,15 +14,24 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
@@ -32,29 +41,22 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "5bcc0a238d880469f949fc7cd24e35f32ab80cbd"
-  version = "v1.12.36"
+  revision = "f63ecde3e92bac72832e9b860480b29792e6a924"
+  version = "v1.17.7"
 
 [[projects]]
-  digest = "1:50772cf1f376b08cb57b4e8e9225775d9f9f4aad8487313afcb66846ceaa5d4c"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
-
-[[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/s3",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "1.12.36"
+  version = "1.17.7"
 
 [prune]
   go-tests = true

--- a/s3-recursive-acl.go
+++ b/s3-recursive-acl.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -15,17 +16,27 @@ func main() {
 	var bucket, region, path, cannedACL string
 	var wg sync.WaitGroup
 	var counter int64
+	var changeError bool
+
 	flag.StringVar(&region, "region", "ap-northeast-1", "AWS region")
 	flag.StringVar(&bucket, "bucket", "s3-bucket", "Bucket name")
 	flag.StringVar(&path, "path", "/", "Path to recurse under")
 	flag.StringVar(&cannedACL, "acl", "public-read", "Canned ACL to assign objects")
 	flag.Parse()
 
-	svc := s3.New(session.New(), &aws.Config{
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
+		SharedConfigState:       session.SharedConfigEnable,
+		Config:                  aws.Config{Region: aws.String(region), CredentialsChainVerboseErrors: aws.Bool(true)},
+	}))
+
+	svc := s3.New(sess, &aws.Config{
 		Region: aws.String(region),
 	})
 
-	err := svc.ListObjectsPages(&s3.ListObjectsInput{
+	changeError = false
+
+	listErr := svc.ListObjectsPages(&s3.ListObjectsInput{
 		Prefix: aws.String(path),
 		Bucket: aws.String(bucket),
 	}, func(page *s3.ListObjectsOutput, lastPage bool) bool {
@@ -42,6 +53,7 @@ func main() {
 				fmt.Println(fmt.Sprintf("Updating '%s'", key))
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "Failed to change permissions on '%s', %v", key, err)
+					changeError = true
 				}
 				defer wg.Done()
 			}(bucket, key, cannedACL)
@@ -51,8 +63,12 @@ func main() {
 
 	wg.Wait()
 
-	if err != nil {
-		panic(fmt.Sprintf("Failed to update object permissions in '%s', %v", bucket, err))
+	if changeError {
+		panic(fmt.Sprintf("Failed to update some object permissions in '%s'", bucket))
+	}
+
+	if listErr != nil {
+		panic(fmt.Sprintf("Failed to list objects in '%s', %v", bucket, listErr))
 	}
 
 	fmt.Println(fmt.Sprintf("Successfully updated permissions on %d objects", counter))


### PR DESCRIPTION
Hi there,

Thanks for this great tool, but for me at first it didn't work as we are using an MFA token to access our AWS services.

It would fail with this message:
`panic: Failed to update object permissions in 'XX-BUCKET-NAME-XX', NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors`

So I hacked a little bit to make it work and improved it here and there.

Overview of my fixes:
- Fixed session creation so AWS MFA logins work
- Upgraded AWS SDK to latest version
- Added .gitignore for IntelliJ (because that's my IDE)
- Exit with failure if one of the objects failed to be modified

Kind regards

Wim