### PR TITLE
Add support for custom endpoint URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An application for recursively setting canned ACL in an AWS S3 bucket.  Especially useful in large buckets.
 
-Usage: `$ AWS_PROFILE=default ./s3-recursive-acl --bucket my-bucket-name-here --region region-here --path path/to/recurse --acl aws-exec-read`
+Usage: `$ AWS_PROFILE=default ./s3-recursive-acl [--endpoint custom-endpoint-url] --bucket my-bucket-name-here --region region-here --path path/to/recurse --acl aws-exec-read`
 
 | Canned ACL                | Applies to        | Permissions added to ACL                                                                                                                                  |
 |---------------------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -14,4 +14,3 @@ Usage: `$ AWS_PROFILE=default ./s3-recursive-acl --bucket my-bucket-name-here --
 | bucket-owner-read         | Object            | Object owner gets FULL_CONTROL. Bucket owner gets READ access. If you specify this canned ACL when creating a bucket, Amazon S3 ignores it.               |
 | bucket-owner-full-control | Object            | Both the object owner and the bucket owner get FULL_CONTROL over the object. If you specify this canned ACL when creating a bucket, Amazon S3 ignores it. |
 | log-delivery-write        | Bucket            | The LogDelivery group gets WRITE and READ_ACP permissions on the bucket.                                                                                  |
-

--- a/s3-recursive-acl.go
+++ b/s3-recursive-acl.go
@@ -12,18 +12,22 @@ import (
 )
 
 func main() {
-	var bucket, region, path, cannedACL string
+	var endpoint, bucket, region, path, cannedACL string
 	var wg sync.WaitGroup
 	var counter int64
+	flag.StringVar(&endpoint, "endpoint", "", "Endpoint URL")
 	flag.StringVar(&region, "region", "ap-northeast-1", "AWS region")
 	flag.StringVar(&bucket, "bucket", "s3-bucket", "Bucket name")
 	flag.StringVar(&path, "path", "/", "Path to recurse under")
 	flag.StringVar(&cannedACL, "acl", "public-read", "Canned ACL to assign objects")
 	flag.Parse()
 
-	svc := s3.New(session.New(), &aws.Config{
-		Region: aws.String(region),
-	})
+	var awsConfig = aws.Config{}
+	if endpoint != "" {
+		awsConfig.Endpoint = aws.String(endpoint)
+	}
+	awsConfig.Region = aws.String(region)
+	svc := s3.New(session.New(), &awsConfig)
 
 	err := svc.ListObjectsPages(&s3.ListObjectsInput{
 		Prefix: aws.String(path),


### PR DESCRIPTION
This PR adds a command line option allowing to specify a custom S3 endpoint URL.

This enables the tool to be used with S3 implementations other than Amazon AWS. It has been tested with DigitalOcean Spaces.