### PR TITLE
Fix not waiting reliably for all updates to complete

### DIFF
--- a/s3-recursive-acl.go
+++ b/s3-recursive-acl.go
@@ -32,8 +32,8 @@ func main() {
 		for _, object := range page.Contents {
 			key := *object.Key
 			counter++
+			wg.Add(1)
 			go func(bucket string, key string, cannedACL string) {
-				wg.Add(1)
 				_, err := svc.PutObjectAcl(&s3.PutObjectAclInput{
 					ACL:    aws.String(cannedACL),
 					Bucket: aws.String(bucket),


### PR DESCRIPTION
Due to WaitGroup.Add being called inside the goroutine the program does not reliably wait for all updates to complete before exiting.

Fixed by moving WaitGroup.Add outside of the goroutine.

Can be reproduced by testing with only a small number of objects:

```shell
$ AWS_PROFILE=default ./s3-recursive-acl --bucket foo --region bar --path baz/ --acl public-read
Successfully updated permissions on 3 objects
```

Note that there is no output "Updating ..."

Output after applying the fix:

```shell
$ AWS_PROFILE=default ./s3-recursive-acl --bucket foo --region bar --path baz/ --acl public-read
Updating 'baz/two'
Updating 'baz/one'
Updating 'baz/three'
Successfully updated permissions on 3 objects
```